### PR TITLE
Check id prop is an Object instance (Object and Array)

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -210,7 +210,7 @@
     };
 
     var watchOne = function (obj, prop, watcher, level, addNRemove) {
-        if ((typeof obj == "string") || (!(obj instanceof Object) && !isArray(obj))) { //accepts only objects and array (not string)
+        if ((typeof obj == "string") || (!(obj instanceof Object) && !isArray(obj)) || prop instanceof Object) { //accepts only objects and array (not string)
             return;
         }
 


### PR DESCRIPTION
Check if prop is passed as an object in watchOne
This was occurring in Marionette Inspector when watching `view._events` and one of its properties is sliced by Backbone.Events. The effect was the creation of an '[object Object]' property in `view._events`